### PR TITLE
Timestamp RangeError: Invalid time value

### DIFF
--- a/dev/src/v1rest/helpers.ts
+++ b/dev/src/v1rest/helpers.ts
@@ -22,7 +22,11 @@ export function stringFromTimestampJson(
     } else if (timestamp.seconds) {
       const date = new Date(Date.UTC(1970, 0, 1));
       date.setUTCSeconds(Number(timestamp.seconds));
-      date.setUTCMilliseconds(Number(timestamp.nanos) / 1000);
+      if (timestamp.nanos) {
+        date.setUTCMilliseconds(Number(timestamp.nanos) / 1000);
+      } else {
+        date.setUTCMilliseconds(0);
+      }
       return date.toISOString();
     } else {
       return undefined;


### PR DESCRIPTION
When using the bountyrush version of nodejs-firestore, I would frequently get the error message: "RangeError: Invalid time value" when trying to create a new Timestamp.  I traced the error to line 22 of v1rest/helper.ts. There is a potential for a divide-by-zero error when nanoseconds = 0.

My proposed fix checks `timestamp.nanos` first to ensure that it is non-zero.  This worked for me when testing locally.
